### PR TITLE
Pick a more optimal, less arbitrary -j value

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,6 @@
-
+NCPU=`cat /proc/cpuinfo |grep vendor_id |wc -l`
+let NCPU=$NCPU+2
+echo "Will build with 'make -j$NCPU' ... please edit this script if incorrect."
 
 pkgname=wine-2.0-rc1
 
@@ -41,7 +43,7 @@ echo "Building Wine-64..."
 cd "$srcdir/$pkgname-64-build"
 
 configure64
-make -j8
+make -j$NCPU
 #make
 
 # Build x32
@@ -52,5 +54,5 @@ echo "Building Wine-32..."
 cd "$srcdir/$pkgname-32-build"
 
 configure32
-make -j8
+make -j$NCPU
 #make


### PR DESCRIPTION
The general rule with -j is to use the number of cores +2. This little addition, stolen from https://github.com/Croteam-official/Serious-Engine provides a more sensible way to determine a good -j.

Lots of people who aren't too familiar with building software are interested in this DLL, using too many threads just slows down the build and this can catch people off guard.